### PR TITLE
chore: Remove unused xml-resolver dependency.

### DIFF
--- a/pgjdbc-core-parent/pom.xml
+++ b/pgjdbc-core-parent/pom.xml
@@ -42,12 +42,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>xml-resolver</groupId>
-            <artifactId>xml-resolver</artifactId>
-            <scope>compile</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-jna</artifactId>
             <scope>compile</scope>

--- a/pgjdbc-versions/pom.xml
+++ b/pgjdbc-versions/pom.xml
@@ -359,11 +359,6 @@
                 -->
             </dependency>
             <dependency>
-                <groupId>xml-resolver</groupId>
-                <artifactId>xml-resolver</artifactId>
-                <version>1.2</version>
-            </dependency>
-            <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.core</artifactId>
                 <version>4.3.1</version>


### PR DESCRIPTION
Now docbook is no longer used this dependency can be removed.
