### PR TITLE
pgjdbc-core-parent: allow limiting build requirements

### DIFF
--- a/pgjdbc-core-parent/pom.xml
+++ b/pgjdbc-core-parent/pom.xml
@@ -29,27 +29,57 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.enterprise</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.github.dblock.waffle</groupId>
-            <artifactId>waffle-jna</artifactId>
-            <scope>compile</scope>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
     <profiles>
+        <profile>
+            <id>waffle-deps</id>
+            <activation>
+                <property>
+                    <name>waffleEnabled</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <properties>
+                <waffleEnabled>true</waffleEnabled>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>com.github.dblock.waffle</groupId>
+                    <artifactId>waffle-jna</artifactId>
+                    <scope>compile</scope>
+                    <optional>true</optional>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>osgi-deps</id>
+            <activation>
+                <property>
+                    <name>osgiEnabled</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <properties>
+                <osgiEnabled>true</osgiEnabled>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.enterprise</artifactId>
+                    <scope>provided</scope>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.core</artifactId>
+                    <scope>provided</scope>
+                    <optional>true</optional>
+                </dependency>
+            </dependencies>
+        </profile>
+
         <profile>
             <id>release-artifacts</id>
             <build>


### PR DESCRIPTION
This commit is aimed to ease the building of pgjdbc from source on
GNU/Linux hosts "offline";  without having  some of the
dependencies installed (otherwise strictly required) and without
some features built-in.

There are two new properties, waffleEnabled and osgiEnabled, both
are set to 'true' by default and are used to turn on/off
corresponding maven profiles.

By specifying '-DwaffleEnabled=false' during maven build we can
build pgjdbc.jar without Windows SSPI authentication support.
By specifying '-DosgiEnabled=false' respectively, you can build
pgjdbc.jar without OSGi Enterprise support.
