### PR TITLE
Require Waffle 1.7.5 for building.

### DIFF
--- a/pgjdbc-core-parent/pom.xml
+++ b/pgjdbc-core-parent/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <template.default.pg.port>5432</template.default.pg.port>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <waffle-jna.version>1.7</waffle-jna.version>
         <postgresql.jdbc.spec>JDBC${jdbc.specification.version}</postgresql.jdbc.spec>
         <postgresql.enforce.jdk.version>1.8</postgresql.enforce.jdk.version>
         <javac.target>1.8</javac.target>

--- a/pgjdbc-versions/pom.xml
+++ b/pgjdbc-versions/pom.xml
@@ -68,7 +68,7 @@
     <properties>
         <template.default.pg.port>5432</template.default.pg.port>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <waffle-jna.version>1.7</waffle-jna.version>
+        <waffle-jna.version>1.8.1</waffle-jna.version>
         <postgresql.jdbc.spec>JDBC${jdbc.specification.version}</postgresql.jdbc.spec>
         <postgresql.driver.fullversion>PostgreSQL ${postgresql.jdbc.spec}</postgresql.driver.fullversion>
         <postgresql.preprocessed.sources.directory>${project.build.directory}/gen-src</postgresql.preprocessed.sources.directory>

--- a/pgjdbc-versions/pom.xml
+++ b/pgjdbc-versions/pom.xml
@@ -68,7 +68,7 @@
     <properties>
         <template.default.pg.port>5432</template.default.pg.port>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <waffle-jna.version>1.8.1</waffle-jna.version>
+        <waffle-jna.version>1.7.5</waffle-jna.version>
         <postgresql.jdbc.spec>JDBC${jdbc.specification.version}</postgresql.jdbc.spec>
         <postgresql.driver.fullversion>PostgreSQL ${postgresql.jdbc.spec}</postgresql.driver.fullversion>
         <postgresql.preprocessed.sources.directory>${project.build.directory}/gen-src</postgresql.preprocessed.sources.directory>


### PR DESCRIPTION
This removes the waffle-jna.version property from pgjdbc-core-parent, because I think
it was added unintentionally there. The value from pgjdbc-versions is inherited
anyway.

All tests pass, but none of them test SSPI auth.

Waffle < 1.7.5 contains a resource leak; 1.8.1 is the most recent release.

There will be a second PR for pgjdbc proper to track the API change made as part of the Waffle fix.
