### PR TITLE
chore: add Automatic-Module-Name

### DIFF
--- a/pgjdbc-core-parent/pom.xml
+++ b/pgjdbc-core-parent/pom.xml
@@ -236,6 +236,7 @@
                                     <Specification-Title>JDBC</Specification-Title>
                                     <Specification-Version>${jdbc.specification.version}</Specification-Version>
                                     <Specification-Vendor>Oracle Corporation</Specification-Vendor>
+                                    <Automatic-Module-Name>org.postgresql.jdbc</Automatic-Module-Name>
                                 </manifestEntries>
                                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                             </archive>


### PR DESCRIPTION
Add Automatic-Module-Name entry to the MANIFEST.MF
Value is `org.postgresql.jdbc`

https://github.com/pgjdbc/pgjdbc/issues/1031